### PR TITLE
local.conf: Build SDK for x86_64

### DIFF
--- a/conf/local.conf.sample
+++ b/conf/local.conf.sample
@@ -2,7 +2,7 @@ CONF_VERSION = "1"
 DL_DIR = "${TOPDIR}/downloads"
 
 MACHINE = "raspberrypi3"
-SDKMACHINE = "i686"
+SDKMACHINE = "x86_64"
 DISTRO = "bistro"
 
 BB_NUMBER_THREADS ?= "${@oe.utils.cpu_count()}"


### PR DESCRIPTION
Same as https://github.com/Pelagicore/meta-pelux-bsp-intel/pull/13 but for RPI this time.