### PR TITLE
bblayers.conf: Add meta-multimedia OE layer

### DIFF
--- a/conf/bblayers.conf.sample
+++ b/conf/bblayers.conf.sample
@@ -12,6 +12,7 @@ BBLAYERS ?= "                                         \
   ${BSPDIR}/sources/meta-openembedded/meta-networking \
   ${BSPDIR}/sources/meta-openembedded/meta-python     \
   ${BSPDIR}/sources/meta-openembedded/meta-ruby       \
+  ${BSPDIR}/sources/meta-openembedded/meta-multimedia \
   ${BSPDIR}/sources/meta-ivi/meta-ivi                 \
   ${BSPDIR}/sources/meta-ivi/meta-ivi-bsp             \
   ${BSPDIR}/sources/meta-pelux-bsp-rpi                \


### PR DESCRIPTION
Some of the meta-openembedded/meta-multimedia components like gupnp,
rygel, gstreamer, dleyna and libmediaart will be used in PELUX.

Signed-off-by: Gordan Markuš <gordan.markus@pelagicore.com>